### PR TITLE
Add VXLAN VNI tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ project-root/
 ├── test_batfish_vxlan.py    # Main test script
 ├── sample_configs/          # Network configuration directory
 │   ├── leaf1.cfg           # Leaf switch configuration
+│   ├── leaf2.cfg           # Additional leaf switch
 │   └── spine1.cfg          # Spine switch configuration
 └── README.md               # This file
 ```
@@ -49,6 +50,9 @@ Contains the leaf switch configuration with:
 - NVE interface configuration
 - VXLAN VNI mapping
 - BGP EVPN neighbor relationships
+
+### leaf2.cfg
+Additional leaf switch configuration mirroring `leaf1.cfg` but with a different router ID.
 
 ### spine1.cfg
 Contains the spine switch configuration with:
@@ -84,6 +88,16 @@ python -m unittest test_batfish_vxlan.BatfishVxlanTest.test_bgp_peers_establishe
 - **Purpose**: Validates BGP EVPN session configuration
 - **Validation**: Analyzes BGP neighbor compatibility
 - **Expected Result**: BGP peers should be properly configured for EVPN
+
+### 3. VXLAN VNI Presence (`test_vxlan_vni_defined`)
+- **Purpose**: Ensures VXLAN VNIs are defined in the fabric
+- **Validation**: Queries VXLAN VNI properties
+- **Expected Result**: At least one VNI should be configured
+
+### 4. Ingress Replication Method (`test_vxlan_ingress_replication_bgp`)
+- **Purpose**: Confirms VNIs use BGP as the ingress replication method
+- **Validation**: Checks the `Ingress_Method` column of VNI properties
+- **Expected Result**: All VNIs should use `BGP` for ingress replication
 
 ## Configuration Requirements
 

--- a/batfish_tests/sample_configs/leaf2.cfg
+++ b/batfish_tests/sample_configs/leaf2.cfg
@@ -1,0 +1,13 @@
+interface nve1
+  no shutdown
+  source-interface loopback0
+  member vni 5001
+    ingress-replication protocol bgp
+!
+router bgp 65001
+  router-id 1.1.1.2
+  neighbor 2.2.2.2 remote-as 65001
+  address-family l2vpn evpn
+    send-community extended
+    advertise l2vpn evpn
+!

--- a/batfish_tests/test_batfish_vxlan.py
+++ b/batfish_tests/test_batfish_vxlan.py
@@ -31,6 +31,20 @@ class BatfishVxlanTest(unittest.TestCase):
         peers = bfq.bgpSessionCompatibility().answer().frame()
         self.assertFalse(peers.empty, "No BGP peers found in snapshot")
 
+    @unittest.skipUnless(PYBATFISH_AVAILABLE, "pybatfish not available")
+    def test_vxlan_vni_defined(self):
+        """Ensure at least one VXLAN VNI is defined"""
+        vnis = bfq.vxlanVniProperties().answer().frame()
+        self.assertFalse(vnis.empty, "No VXLAN VNIs found in snapshot")
+
+    @unittest.skipUnless(PYBATFISH_AVAILABLE, "pybatfish not available")
+    def test_vxlan_ingress_replication_bgp(self):
+        """Validate that VXLAN uses BGP for ingress replication"""
+        vnis = bfq.vxlanVniProperties().answer().frame()
+        if not vnis.empty and "Ingress_Method" in vnis.columns:
+            self.assertTrue((vnis["Ingress_Method"] == "BGP").all(),
+                            "Ingress replication not set to BGP for all VNIs")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- include an additional sample leaf config
- test VXLAN VNI presence and BGP replication method
- document new config and tests in README

## Testing
- `python -m unittest batfish_tests.test_batfish_vxlan -v`

------
https://chatgpt.com/codex/tasks/task_e_688668e58c3483248e2437a440b1d24c